### PR TITLE
Feature/admin wei

### DIFF
--- a/src/components/Dashboard/ProposalCard.vue
+++ b/src/components/Dashboard/ProposalCard.vue
@@ -8,7 +8,7 @@
             <!-- <img src="https://picsum.photos/id/684/600/400" alt="" class="rounded-pill me-2 me-md-4 me-lg-8" width="48" height="48"> -->
             <img :src="proposalData.proposalMainImage" alt="" class="rounded-pill me-2 me-md-4 me-lg-8" width="48" height="48">
             <div class="flex-grow-1 text-white text-truncate">
-              <p class="mb-0 fs-12 lh-sm mb-1">2024.02.13</p>
+              <!-- <p class="mb-0 fs-12 lh-sm mb-1">2024.02.13</p> -->
               <p class="mb-0 fs-14 fs-md-5 text-truncate">{{proposalData.proposalTitle}}</p>
             </div>
           </div>

--- a/src/components/Dashboard/ProposalCard.vue
+++ b/src/components/Dashboard/ProposalCard.vue
@@ -6,7 +6,7 @@
         <div class="col-12 col-sm-7">
           <div class="d-flex align-items-center">
             <!-- <img src="https://picsum.photos/id/684/600/400" alt="" class="rounded-pill me-2 me-md-4 me-lg-8" width="48" height="48"> -->
-            <img :src="proposalData.proposalMainImage" alt="" class="rounded-pill me-2 me-md-4 me-lg-8" width="48" height="48">
+            <img :src="proposalData.proposalMainImage" alt="" class="object-fit-cover rounded-pill me-2 me-md-4 me-lg-8" width="48" height="48">
             <div class="flex-grow-1 text-white text-truncate">
               <!-- <p class="mb-0 fs-12 lh-sm mb-1">2024.02.13</p> -->
               <p class="mb-0 fs-14 fs-md-5 text-truncate">{{proposalData.proposalTitle}}</p>

--- a/src/components/Dashboard/RealtimeBannerPreview.vue
+++ b/src/components/Dashboard/RealtimeBannerPreview.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="container py-15">
+    <swiper
+      ref="swiper"
+      :modules="[EffectFade]"
+      effect="fade"
+      :slides-per-view="3"
+      :space-between="120"
+      :centered-slides="true"
+      :breakpoints="{
+          390: {
+            slidesPerView: 1,
+          },
+        }"
+      :autoplay="{
+        delay: 5000,
+        disableOnInteraction: false,
+      }"
+      @swiperslidechange="onSlideChange"
+      class="rounded-5 col-12 object-fit-cover"
+      style="height: 650px;"
+    >
+      <swiper-slide
+        v-for="(item, index) in bannerData"
+        :key="`${index}-bn`"
+        >
+        <div class="rounded-5">
+          <div class="d-flex flex-column justify-content-center align-items-center">
+            <RouterLink to="/member" class="position-relative col-12 rounded-5 shadow">
+              <img
+                :src="item.imgUrl"
+                class="img-fluid rounded-5 w-100 object-fit-cover"
+                style="height: 650px;"
+                alt="推動夢想不是夢概念圖">
+              <div class="bg-primary-dark col-12 py-7 rounded-bottom-5 position-absolute bottom-0">
+                <h4 class="text-secondary-light text-center lterSpc-10 mb-0 mx-8 bn-hover">
+                  立刻加入會員，一起追夢去
+                  <span>
+                    <RightArrow style="width:24px;color: var(--bs-secondary-light);margin-top: -2 px;" ></RightArrow>
+                  </span>
+                </h4>
+              </div>
+            </RouterLink>
+            <div class="d-flex flex-column align-items-center position-absolute top-24 top-sm-24 px-10">
+              <img
+                src="/images/home/w-biglogo.svg"
+                class="img-fluid mb-5 col-12"
+                alt="">
+              <p class="fs-3 fw-light text-white mb-0 lterSpc-10">推動夢想不是夢 !</p>
+            </div>
+          </div>
+        </div>
+      </swiper-slide>
+    </swiper>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.bn-hover {
+  &:hover {
+    transform: scale(1.05);
+    transition: transform 0.3s ease;
+    cursor: pointer;
+  }
+}
+</style>
+
+<script>
+/* eslint-disable no-unused-vars */
+
+import { Swiper, SwiperSlide } from 'swiper/vue';
+import { EffectFade, Pagination, Navigation } from 'swiper/modules';
+import RightArrow from '@/components/icons/RightArrow.vue';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/effect-fade';
+
+const { VITE_URL, VITE_PATH } = import.meta.env;
+
+export default {
+  props: ['bannerData'],
+  data() {
+    return {
+      modules: [Navigation, Pagination],
+      bnData: [],
+      EffectFade,
+    };
+  },
+  methods: {
+    onSlideChange() {
+    },
+    // getBnUrl() {
+    //   this.$http.get(`${VITE_URL}/dreamboost/banner/guest/banner`)
+    //     .then((response) => {
+    //       this.bnData = response.data.data.result;
+    //     })
+    //     .catch(() => {
+    //     });
+    // },
+  },
+  components: {
+    RightArrow,
+    Swiper,
+    SwiperSlide,
+  },
+  mounted() {
+    // this.getBnUrl();
+  },
+  created() {
+  },
+};
+</script>
+
+<style scoped>
+
+.swiper-slide img {
+  display: block;
+}
+</style>

--- a/src/views/front/UbNews.vue
+++ b/src/views/front/UbNews.vue
@@ -11,7 +11,7 @@
         <template v-if="apiUserMessages">
           <div>
             <div class="accordion p-4 pb-11 border border-primary-light rounded-3" id="messageAccordion">
-              <AccordionItem v-for="(item,index) in apiUserMessages" :key="`${index}-AccordionList`" :message-data="item"></AccordionItem>
+              <AccordionItem v-for="(item,index) in messagesSorted" :key="`${index}-AccordionList`" :message-data="item"></AccordionItem>
             </div>
             <div class="d-flex flex-column mt-5">
               <button
@@ -57,8 +57,9 @@ export default {
     };
   },
   computed: {
-    // messagesSorted() {
-    // },
+    messagesSorted() {
+      return this.apiUserMessages.slice().sort((a, b) => b.messageTime - a.messageTime);
+    },
   },
   methods: {
     getUserMessages() {


### PR DESCRIPTION
前台：調整個人訊息的排序（新的在上面）
後台：
- 調整方案審查的頭像object-fit-cover防止變形；移除方案審查的時間。
- 調整更換Bn分頁的使用者互動（新增loading,toast)。
- 增加更換Bn分頁的即時預覽元件(使用props傳入資料渲染swipter，而不在元件內取得API資料)